### PR TITLE
bf: racing condition

### DIFF
--- a/pte-browser-extension-sdk/src/action.ts
+++ b/pte-browser-extension-sdk/src/action.ts
@@ -13,17 +13,17 @@ export const waitForAction = async <SuccessType extends ActionTypes>(
   errorTypes?: ActionType[]
 ): Promise<SuccessType> =>
   new Promise((resolve, reject) => {
-    window.addEventListener(
-      "radix#chromeExtension#receive",
-      (event) => {
-        const { action } = (event as CustomEvent<MessageStoreItem<ActionTypes>>)
-          .detail;
+    let listener = function(event){
+      const { action } = (event as CustomEvent<MessageStoreItem<ActionTypes>>)
+        .detail;
 
-        if (action.type === successType) resolve(action as SuccessType);
-        else if (errorTypes?.includes(action.type)) reject(action);
-      },
-      {
-        once: true,
-      }
-    );
+      if (action.type === successType) {
+        window.removeEventListener("radix#chromeExtension#receive", listener);
+        resolve(action as SuccessType);
+      } else if (errorTypes?.includes(action.type)) {
+        window.removeEventListener("radix#chromeExtension#receive", listener);
+        reject(action);
+      } else console.log("MESSAGE IGNORED !", event);
+    }
+    window.addEventListener("radix#chromeExtension#receive", listener);
   });


### PR DESCRIPTION
## The bug

If a getAccountAddress and a signTransaction are running in parallel, you have two waitForAction waiting. The first one to receive the message it expect will be successful. While the other one will ignore the message and because of the `once: true` will stop to listen.

so some promise to be never resolved

## The solution

don't use `once: true` but unsubscribe the listener when the promise is resolved/rejected
